### PR TITLE
Work on modernmen-yolo project

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,8 +18,8 @@ jest.mock('next/navigation', () => ({
       defaultLocale: 'en',
     }
   },
-  userchParams() {
-    return new URLrchParams()
+  useSearchParams() {
+    return new URLSearchParams()
   },
   usePathname() {
     return '/'

--- a/modernmen-yolo/src/app/api/admin/[...payload]/route.ts
+++ b/modernmen-yolo/src/app/api/admin/[...payload]/route.ts
@@ -4,7 +4,7 @@ import getPayloadClient from '../../../../payload'
 export async function GET(request: NextRequest) {
   try {
     const payload = await getPayloadClient()
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
 
     // Extract the path from the URL
     const path = request.url.split('/api/admin/')[1] || ''
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     const response = await payload.send({
       method: 'GET',
       url: `/${path}`,
-      query: Object.fromEntries(rchParams),
+      query: Object.fromEntries(searchParams),
     })
 
     return Response.json(response)
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   try {
     const payload = await getPayloadClient()
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
 
     // Extract the path from the URL
     const path = request.url.split('/api/admin/')[1] || ''
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
       method: 'POST',
       url: `/${path}`,
       data: body,
-      query: Object.fromEntries(rchParams),
+      query: Object.fromEntries(searchParams),
     })
 
     return Response.json(response)
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
 export async function PUT(request: NextRequest) {
   try {
     const payload = await getPayloadClient()
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
 
     // Extract the path from the URL
     const path = request.url.split('/api/admin/')[1] || ''
@@ -71,7 +71,7 @@ export async function PUT(request: NextRequest) {
       method: 'PUT',
       url: `/${path}`,
       data: body,
-      query: Object.fromEntries(rchParams),
+      query: Object.fromEntries(searchParams),
     })
 
     return Response.json(response)
@@ -87,7 +87,7 @@ export async function PUT(request: NextRequest) {
 export async function DELETE(request: NextRequest) {
   try {
     const payload = await getPayloadClient()
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
 
     // Extract the path from the URL
     const path = request.url.split('/api/admin/')[1] || ''
@@ -96,7 +96,7 @@ export async function DELETE(request: NextRequest) {
     const response = await payload.send({
       method: 'DELETE',
       url: `/${path}`,
-      query: Object.fromEntries(rchParams),
+      query: Object.fromEntries(searchParams),
     })
 
     return Response.json(response)

--- a/modernmen-yolo/src/app/api/business-documentation/metrics/route.ts
+++ b/modernmen-yolo/src/app/api/business-documentation/metrics/route.ts
@@ -25,9 +25,9 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Insufficient permissions' }, { status: 403 })
     }
 
-    const { rchParams } = new URL(request.url)
-    const startDate = rchParams.get('startDate')
-    const endDate = rchParams.get('endDate')
+    const { searchParams } = new URL(request.url)
+    const startDate = searchParams.get('startDate')
+    const endDate = searchParams.get('endDate')
 
     let dateRange: { start: Date; end: Date } | undefined
     if (startDate && endDate) {

--- a/modernmen-yolo/src/app/api/business-documentation/route.ts
+++ b/modernmen-yolo/src/app/api/business-documentation/route.ts
@@ -21,26 +21,26 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
     
     // Parse filter parameters
     const filter: BusinessDocumentationFilter = {
-      type: rchParams.get('type')?.split(',') as any,
-      category: rchParams.get('category')?.split(',') as any,
-      status: rchParams.get('status')?.split(',') as any,
-      difficulty: rchParams.get('difficulty')?.split(',') as any,
-      priority: rchParams.get('priority')?.split(',') as any,
-      tags: rchParams.get('tags')?.split(','),
-      author: rchParams.get('author')?.split(','),
-      rchQuery: rchParams.get('q') || undefined,
-      dateRange: rchParams.get('startDate') && rchParams.get('endDate') ? {
-        start: new Date(rchParams.get('startDate')!),
-        end: new Date(rchParams.get('endDate')!)
+      type: searchParams.get('type')?.split(',') as any,
+      category: searchParams.get('category')?.split(',') as any,
+      status: searchParams.get('status')?.split(',') as any,
+      difficulty: searchParams.get('difficulty')?.split(',') as any,
+      priority: searchParams.get('priority')?.split(',') as any,
+      tags: searchParams.get('tags')?.split(','),
+      author: searchParams.get('author')?.split(','),
+      rchQuery: searchParams.get('q') || undefined,
+      dateRange: searchParams.get('startDate') && searchParams.get('endDate') ? {
+        start: new Date(searchParams.get('startDate')!),
+        end: new Date(searchParams.get('endDate')!)
       } : undefined
     }
 
-    const page = parseInt(rchParams.get('page') || '1')
-    const limit = parseInt(rchParams.get('limit') || '20')
+    const page = parseInt(searchParams.get('page') || '1')
+    const limit = parseInt(searchParams.get('limit') || '20')
 
     const result = await docService.rchDocumentation(filter, user.role, page, limit)
 

--- a/modernmen-yolo/src/app/api/business-documentation/templates/route.ts
+++ b/modernmen-yolo/src/app/api/business-documentation/templates/route.ts
@@ -20,9 +20,9 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { rchParams } = new URL(request.url)
-    const type = rchParams.get('type') || undefined
-    const category = rchParams.get('category') || undefined
+    const { searchParams } = new URL(request.url)
+    const type = searchParams.get('type') || undefined
+    const category = searchParams.get('category') || undefined
 
     const templates = await docService.getTemplates(type, category)
 

--- a/modernmen-yolo/src/app/api/documentation/search/route.ts
+++ b/modernmen-yolo/src/app/api/documentation/search/route.ts
@@ -41,20 +41,20 @@ const rchService = new DocumentationrchService(rchConfig)
 
 export async function GET(request: NextRequest) {
   try {
-    const { rchParams } = new URL(request.url)
-    const query = rchParams.get('q') || ''
-    const page = parseInt(rchParams.get('page') || '1')
-    const limit = parseInt(rchParams.get('limit') || '20')
-    const sortField = rchParams.get('sort') || 'relevance'
-    const sortDirection = rchParams.get('order') || 'desc'
+    const { searchParams } = new URL(request.url)
+    const query = searchParams.get('q') || ''
+    const page = parseInt(searchParams.get('page') || '1')
+    const limit = parseInt(searchParams.get('limit') || '20')
+    const sortField = searchParams.get('sort') || 'relevance'
+    const sortDirection = searchParams.get('order') || 'desc'
     
     // Parse filters from query parameters
-    const categories = rchParams.get('categories')?.split(',').filter(Boolean) || []
-    const contentTypes = rchParams.get('types')?.split(',').filter(Boolean) || []
-    const tags = rchParams.get('tags')?.split(',').filter(Boolean) || []
-    const difficulty = rchParams.get('difficulty')?.split(',').filter(Boolean) || []
-    const authors = rchParams.get('authors')?.split(',').filter(Boolean) || []
-    const sections = rchParams.get('sections')?.split(',').filter(Boolean) || []
+    const categories = searchParams.get('categories')?.split(',').filter(Boolean) || []
+    const contentTypes = searchParams.get('types')?.split(',').filter(Boolean) || []
+    const tags = searchParams.get('tags')?.split(',').filter(Boolean) || []
+    const difficulty = searchParams.get('difficulty')?.split(',').filter(Boolean) || []
+    const authors = searchParams.get('authors')?.split(',').filter(Boolean) || []
+    const sections = searchParams.get('sections')?.split(',').filter(Boolean) || []
 
     // Get user session and role
     const session = await getServerSession()

--- a/modernmen-yolo/src/app/api/search/route.ts
+++ b/modernmen-yolo/src/app/api/search/route.ts
@@ -6,12 +6,12 @@ import { logger } from '@/lib/logger'
 
 async function handlerch(request: NextRequest) {
   try {
-    const { rchParams } = new URL(request.url)
-    const query = rchParams.get('q')
-    const category = rchParams.get('category')
-    const type = rchParams.get('type')
-    const limit = rchParams.get('limit')
-    const offset = rchParams.get('offset')
+    const { searchParams } = new URL(request.url)
+    const query = searchParams.get('q')
+    const category = searchParams.get('category')
+    const type = searchParams.get('type')
+    const limit = searchParams.get('limit')
+    const offset = searchParams.get('offset')
 
     if (!query) {
       return NextResponse.json(

--- a/modernmen-yolo/src/app/api/storybook/route.ts
+++ b/modernmen-yolo/src/app/api/storybook/route.ts
@@ -5,10 +5,10 @@ import { logger } from '@/lib/logger'
 
 async function getStorybookDocumentation(request: NextRequest) {
   try {
-    const { rchParams } = new URL(request.url)
-    const component = rchParams.get('component')
-    const category = rchParams.get('category')
-    const query = rchParams.get('query')
+    const { searchParams } = new URL(request.url)
+    const component = searchParams.get('component')
+    const category = searchParams.get('category')
+    const query = searchParams.get('query')
 
     logger.info('Fetching storybook documentation', {
       component,

--- a/modernmen-yolo/src/app/api/testimonials/route.ts
+++ b/modernmen-yolo/src/app/api/testimonials/route.ts
@@ -83,10 +83,10 @@ const sampleTestimonials: Testimonial[] = [
 
 export async function GET(request: NextRequest) {
   try {
-    const { rchParams } = new URL(request.url)
-    const stylistId = rchParams.get('stylistId')
-    const limit = parseInt(rchParams.get('limit') || '10')
-    const page = parseInt(rchParams.get('page') || '1')
+    const { searchParams } = new URL(request.url)
+    const stylistId = searchParams.get('stylistId')
+    const limit = parseInt(searchParams.get('limit') || '10')
+    const page = parseInt(searchParams.get('page') || '1')
 
     let filteredTestimonials = sampleTestimonials
 

--- a/modernmen-yolo/src/app/api/users/route.ts
+++ b/modernmen-yolo/src/app/api/users/route.ts
@@ -25,13 +25,13 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const { rchParams } = new URL(request.url)
+    const { searchParams } = new URL(request.url)
     const filters: UserFilters = {
-      role: rchParams.get('role') || undefined,
-      isActive: rchParams.get('isActive') === 'true' ? true : rchParams.get('isActive') === 'false' ? false : undefined,
-      rch: rchParams.get('rch') || undefined,
-      limit: parseInt(rchParams.get('limit') || '20'),
-      page: parseInt(rchParams.get('page') || '1')
+      role: searchParams.get('role') || undefined,
+      isActive: searchParams.get('isActive') === 'true' ? true : searchParams.get('isActive') === 'false' ? false : undefined,
+      rch: searchParams.get('rch') || undefined,
+      limit: parseInt(searchParams.get('limit') || '20'),
+      page: parseInt(searchParams.get('page') || '1')
     }
 
     const payload = await getPayloadClient()

--- a/modernmen-yolo/src/app/auth/error/page.tsx
+++ b/modernmen-yolo/src/app/auth/error/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { userchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import Link from 'next/link'
@@ -13,8 +13,8 @@ const errorMessages: Record<string, string> = {
 }
 
 const AuthErrorPage = () => {
-  const rchParams = userchParams()
-  const error = rchParams?.get('error') || 'Default'
+  const searchParams = useSearchParams()
+  const error = searchParams?.get('error') || 'Default'
 
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">

--- a/modernmen-yolo/src/app/auth/reset-password/page.tsx
+++ b/modernmen-yolo/src/app/auth/reset-password/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { userchParams, useRouter } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -20,9 +20,9 @@ export default function ResetPasswordPage() {
   const [isLoading, setIsLoading] = useState(false)
   const [isValidToken, setIsValidToken] = useState<boolean | null>(null)
 
-  const rchParams = userchParams()
+  const searchParams = useSearchParams()
   const router = useRouter()
-  const token = rchParams.get('token')
+  const token = searchParams.get('token')
 
   useEffect(() => {
     if (!token) {

--- a/modernmen-yolo/src/app/documentation/search/page.tsx
+++ b/modernmen-yolo/src/app/documentation/search/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import React, { Suspense } from 'react';
-import { userchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { Documentationrch } from '@/components/documentation/Documentationrch';
 import { Card, CardContent } from '@/components/ui/card';
 import { rch, Loader2 } from '@/lib/icon-mapping';
 
 function rchPageContent() {
-  const rchParams = userchParams();
-  const initialQuery = rchParams.get('q') || '';
+  const searchParams = useSearchParams();
+  const initialQuery = searchParams.get('q') || '';
 
   return (
     <div className="max-w-6xl">

--- a/modernmen-yolo/src/app/portal/login/page.tsx
+++ b/modernmen-yolo/src/app/portal/login/page.tsx
@@ -2,7 +2,7 @@
 
 import { getProviders, signIn, getSession } from 'next-auth/react'
 import { useState, useEffect } from 'react'
-import { userchParams, useRouter } from 'next/navigation'
+import { useSearchParams, useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -16,11 +16,11 @@ export default function PortalLoginPage() {
   const [password, setPassword] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [providers, setProviders] = useState<any>(null)
-  const rchParams = userchParams()
+  const searchParams = useSearchParams()
   const router = useRouter()
 
-  const callbackUrl = rchParams?.get('callbackUrl') || '/portal'
-  const error = rchParams?.get('error')
+  const callbackUrl = searchParams?.get('callbackUrl') || '/portal'
+  const error = searchParams?.get('error')
 
   useEffect(() => {
     const getProvidersData = async () => {

--- a/modernmen-yolo/src/components/admin/AuditLogs.tsx
+++ b/modernmen-yolo/src/components/admin/AuditLogs.tsx
@@ -49,7 +49,7 @@ export function AuditLogs() {
   const fetchAuditLogs = async () => {
     try {
       setLoading(true)
-      const params = new URLrchParams()
+      const params = new URLSearchParams()
       if (rchTerm) params.set('rch', rchTerm)
       if (actionFilter !== 'all') params.set('action', actionFilter)
       if (resourceFilter !== 'all') params.set('resource', resourceFilter)

--- a/modernmen-yolo/src/components/admin/EmployeeManagement.tsx
+++ b/modernmen-yolo/src/components/admin/EmployeeManagement.tsx
@@ -52,7 +52,7 @@ export function EmployeeManagement() {
   const fetchEmployees = async () => {
     try {
       setLoading(true)
-      const params = new URLrchParams()
+      const params = new URLSearchParams()
       if (rchTerm) params.set('rch', rchTerm)
       if (statusFilter !== 'all') {
         params.set('isActive', statusFilter === 'active' ? 'true' : 'false')

--- a/modernmen-yolo/src/components/admin/UserManagement.tsx
+++ b/modernmen-yolo/src/components/admin/UserManagement.tsx
@@ -46,7 +46,7 @@ export function UserManagement() {
   const fetchUsers = async () => {
     try {
       setLoading(true)
-      const params = new URLrchParams()
+      const params = new URLSearchParams()
       if (rchTerm) params.set('rch', rchTerm)
       if (roleFilter !== 'all') params.set('role', roleFilter)
       if (statusFilter !== 'all') {

--- a/modernmen-yolo/src/components/documentation/APITester.tsx
+++ b/modernmen-yolo/src/components/documentation/APITester.tsx
@@ -11,7 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
-import { Play, Copy, Download, Clock, AlertTriangle, CheckCircle } from '@/lib/icon-mapping'
+import { Play as PlayIcon, Copy as CopyIcon, Download as DownloadIcon, Clock, AlertTriangle, CheckCircle, AlertCircle, History as HistoryIcon } from '@/lib/icon-mapping'
 import { APIEndpoint, APITestRequest, APITestResponse, APITestHistory } from '@/types/api-documentation'
 import { cn } from '@/lib/utils'
 
@@ -126,7 +126,7 @@ export function APITester({ endpoint, authentication, onClose, onTest }: APITest
     })
 
     // Add query parameters
-    const queryParams = new URLrchParams()
+    const queryParams = new URLSearchParams()
     endpoint.parameters.query.forEach(param => {
       const value = parameters[param.name]
       if (value !== undefined && value !== '') {

--- a/modernmen-yolo/src/components/documentation/CodeGenerator.tsx
+++ b/modernmen-yolo/src/components/documentation/CodeGenerator.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { Copy, Download, Code } from '@/lib/icon-mapping'
+import { Copy as CopyIcon, Download as DownloadIcon, Code as CodeIcon } from '@/lib/icon-mapping'
 import { APIEndpoint, SDKGenerationConfig, CodeGenerationTemplate } from '@/types/api-documentation'
 import { cn } from '@/lib/utils'
 
@@ -270,7 +270,7 @@ interface ${endpoint.operationId}Request {
   })
 
   const queryStringCode = endpoint.parameters.query.length > 0 ? `
-  const queryParams = new URLrchParams()
+  const queryParams = new URLSearchParams()
   ${endpoint.parameters.query.map(p => `
   if (params.${p.name} !== undefined) {
     queryParams.append('${p.name}', String(params.${p.name}))
@@ -313,7 +313,7 @@ function generateJavaScriptCode(endpoint: APIEndpoint, baseUrl: string, includeA
 
   const pathParams = endpoint.parameters.path.map(p => p.name).join(', ')
   const queryParams = endpoint.parameters.query.length > 0 ? `
-  const queryParams = new URLrchParams()
+  const queryParams = new URLSearchParams()
   ${endpoint.parameters.query.map(p => `
   if (${p.name} !== undefined) {
     queryParams.append('${p.name}', String(${p.name}))

--- a/modernmen-yolo/src/components/documentation/ComponentPlayground.tsx
+++ b/modernmen-yolo/src/components/documentation/ComponentPlayground.tsx
@@ -19,7 +19,7 @@ class ClientStorybookService {
     const url = new URL('/api/storybook', window.location.origin)
     if (params) {
       Object.entries(params).forEach(([key, value]) => {
-        url.rchParams.set(key, value)
+        url.searchParams.set(key, value)
       })
     }
 

--- a/modernmen-yolo/src/components/ui/NotificationHistory.tsx
+++ b/modernmen-yolo/src/components/ui/NotificationHistory.tsx
@@ -37,7 +37,7 @@ export function NotificationHistory({ userId, className = '' }: NotificationHist
   const fetchNotifications = useCallback(async () => {
     try {
       setLoading(true)
-      const params = new URLrchParams({
+      const params = new URLSearchParams({
         page: currentPage.toString(),
         limit: '20'
       })

--- a/modernmen-yolo/src/hooks/usePayloadIntegration.ts
+++ b/modernmen-yolo/src/hooks/usePayloadIntegration.ts
@@ -71,7 +71,7 @@ export function usePayloadIntegration() {
     setError(null)
 
     try {
-      const params = new URLrchParams({
+      const params = new URLSearchParams({
         q: query,
         collections: collections.join(','),
         limit: limit.toString()
@@ -106,7 +106,7 @@ export function usePayloadIntegration() {
     setError(null)
 
     try {
-      const params = new URLrchParams()
+      const params = new URLSearchParams()
       if (dateRange) {
         params.append('startDate', dateRange.start.toISOString())
         params.append('endDate', dateRange.end.toISOString())
@@ -184,7 +184,7 @@ export function usePayloadIntegration() {
     setError(null)
 
     try {
-      const params = new URLrchParams()
+      const params = new URLSearchParams()
       
       Object.entries(filters).forEach(([key, value]) => {
         if (value !== undefined) {

--- a/modernmen-yolo/src/lib/business-documentation-service.ts
+++ b/modernmen-yolo/src/lib/business-documentation-service.ts
@@ -538,8 +538,8 @@ export class BusinessDocumentationService {
     if (data && method !== 'GET') {
       options.body = JSON.stringify(data)
     } else if (data && method === 'GET') {
-      const params = new URLrchParams(data)
-      const response = await fetch(`${url}?${params}`, options)
+      const params = new URLSearchParams(data as Record<string, string>)
+      const response = await fetch(`${url}?${params.toString()}`, options)
       return response.json()
     }
 

--- a/modernmen-yolo/src/lib/smsService.ts
+++ b/modernmen-yolo/src/lib/smsService.ts
@@ -52,7 +52,7 @@ class SMSService {
           'Authorization': `Basic ${Buffer.from(`${this.config.accountSid}:${this.config.authToken}`).toString('base64')}`,
           'Content-Type': 'application/x-www-form-urlencoded',
         },
-        body: new URLrchParams({
+        body: new URLSearchParams({
           From: this.config.fromNumber,
           To: smsData.to,
           Body: smsData.message,

--- a/modernmen-yolo/src/lib/validation-utils.ts
+++ b/modernmen-yolo/src/lib/validation-utils.ts
@@ -32,14 +32,14 @@ export async function validateRequestBody<T>(
 }
 
 /**
- * Validates URL rch parameters
+ * Validates URL search parameters
  */
 export function validaterchParams<T>(
-  rchParams: URLrchParams,
+  searchParams: URLSearchParams,
   schema: z.ZodSchema<T>
 ): ValidationResult<T> {
   try {
-    const params = Object.fromEntries(rchParams.entries())
+    const params = Object.fromEntries(searchParams.entries())
     const validatedData = schema.parse(params)
     return { success: true, data: validatedData }
   } catch (error) {

--- a/modernmen-yolo/src/middleware.ts
+++ b/modernmen-yolo/src/middleware.ts
@@ -65,8 +65,8 @@ export async function middleware(request: NextRequest) {
     if (!token || token.role !== 'admin') {
       const url = request.nextUrl.clone()
       url.pathname = '/documentation'
-      url.rchParams.set('error', 'access_denied')
-      url.rchParams.set('section', 'admin')
+      url.searchParams.set('error', 'access_denied')
+      url.searchParams.set('section', 'admin')
       return NextResponse.redirect(url)
     }
   }


### PR DESCRIPTION
Fix `useSearchParams` and `URLSearchParams` typos across the `modernmen-yolo` project to resolve URL parameter handling bugs.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e961167-cdd4-4481-bad3-c74946c106d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e961167-cdd4-4481-bad3-c74946c106d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Replace incorrect URL parameter handling across the modernmen-yolo project by standardizing on Next’s useSearchParams and the browser’s URLSearchParams API and improve content creation error handling.

Bug Fixes:
- Correct all instances of ‘rchParams’/‘URLrchParams’ to ‘searchParams’/‘URLSearchParams’ for consistent query parsing in API routes, hooks, services, and components
- Fix Next.js client components to use useSearchParams instead of userchParams for reading query parameters

Enhancements:
- Refine POST endpoint in documentation API to perform synchronous validation and return structured error responses on failure

Tests:
- Update jest.mock for next/navigation to stub useSearchParams properly